### PR TITLE
New feature: ok() without callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ or even no callback at all:
 //if there is an error with fs.writeFile, THROW it
 //if there was no error, do nothing
 
-fs.writeFile(path, ok());
+fs.writeFile('/some/file', 'hello', ok());
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ function doSomethingOrDie(path, callback) {
 
 ```
 
+or even no callback at all:
+
+```js
+//if there is an error with fs.writeFile, THROW it
+//if there was no error, do nothing
+
+fs.writeFile(path, ok());
+
+```
+
+
 ## domains
 
 Throwing errors is _probably_ not what you want to do.

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ If domains are in use, defer the error to the domain's error handler by using `p
 
 ## without okay
 ```js
-var doSomething = function(path, callback) {
+function doSomething(path, cb) {
   fs.readDir(path, function(err, files) {
-    if(err) return callback(err);
+    if(err) return cb(err);
     async.map(files, fs.readFile, function(err, contents) {
-      if(err) return callback(err);
-      return callback(null, contents.join('\n'));
+      if(err) return cb(err);
+      return cb(null, contents.join('\n'));
     });
   });
 };
@@ -20,28 +20,53 @@ var doSomething = function(path, callback) {
 ## with okay
 ```js
 var ok = require('okay');
-var doSomething = function(path, callback) {
-  //if path does not exist, bubble the error out to the
-  //callback function right away
-  //if there was no error, call the new error-less callback
-  fs.readDir(path, ok(callback, function(files)){
 
-    //if there was an error reading any file, bubble the error out to the
-    //callback function right away
-    //if there was no error, call the new error-less callback
-    async.map(files, fs.readFile, ok(callback, function(contents) {
-      return callback(null, contents.join('\n'));
+function doSomething(path, cb) {
+  fs.readDir(path, ok(cb, function(files)){
+    async.map(files, fs.readFile, ok(cb, function(contents) {
+      return cb(null, contents.join('\n'));
     }));
   });
 };
+```
 
-//okay also supports a single callback
-var doSomethingOrDie = function(path, callback) {
+The same code with annotations:
+
+```js
+var ok = require('okay');
+
+function doSomething(path, cb) {
+
+  //if path does not exist, bubble the error out to the
+  //callback function right away
+  //if there was no error, call the new error-less cb
+
+  fs.readDir(path, ok(cb, function(files)){
+
+    //if there was an error reading any file, bubble the error out to the
+    //callback function right away
+    //if there was no error, call the new error-less cb
+
+    async.map(files, fs.readFile, ok(cb, function(contents) {
+      return cb(null, contents.join('\n'));
+    }));
+  });
+};
+```
+
+okay also supports a single callback:
+
+```js
+function doSomethingOrDie(path, callback) {
+
   //if there is an error with fs.readDir, THROW it
   //if there was no error, call the new error-less callback
+
   fs.readDir(path, ok(function(files) {
+
     //if there was an error reading any file, THROW it
     //if there was no error, call the new error-less callback
+
     async.map(files, fs.ReadFile, ok(function(contents) {
       return callback(null, contents.join('\n'));
     }));

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var sliced = require('sliced');
-var twoArgHandler = function(parent, callback) {
+function twoArgHandler(parent, callback) {
   return function(err) {
     if(err) {
       parent(err);
@@ -7,18 +7,18 @@ var twoArgHandler = function(parent, callback) {
       callback.apply(callback, sliced(arguments, 1));
     }
   }
-};
+}
 
 //bind callbacks with active domains
-var withDomains = function(parent, callback) {
+function withDomains(parent, callback) {
   if(callback) {
     return process.domain.bind(twoArgHandler(parent, callback));
   }
   return process.domain.intercept(parent);
-};
+}
 
 //bind callbacks without an active domain
-var withoutDomains = function(parent, callback) {
+function withoutDomains(parent, callback) {
   if(callback) {
     return twoArgHandler(parent, callback);
   }
@@ -27,7 +27,7 @@ var withoutDomains = function(parent, callback) {
     if(err) throw err;
     parent.apply(parent, sliced(arguments, 1));
   }
-};
+}
 
 module.exports = function(parent, callback) {
   return process.domain ? withDomains(parent, callback) : withoutDomains(parent, callback);

--- a/index.js
+++ b/index.js
@@ -29,6 +29,11 @@ function withoutDomains(parent, callback) {
   }
 }
 
+function zeroArgHandler(err) {
+  if(err) throw err;
+}
+
 module.exports = function(parent, callback) {
+  if (!parent) return zeroArgHandler;
   return process.domain ? withDomains(parent, callback) : withoutDomains(parent, callback);
 };

--- a/package.json
+++ b/package.json
@@ -6,15 +6,18 @@
   "scripts": {
     "test": "./node_modules/.bin/mocha"
   },
-  "repository": "",
-  "keywords": "domain domains",
-  "author": "",
+  "repository": "brianc/node-okay",
+  "keywords": [
+    "domain",
+    "domains"
+  ],
+  "author": "Brian C <brian.m.carlson@gmail.com>",
   "license": "MIT",
   "dependencies": {
     "sliced": "0.0.5"
   },
   "devDependencies": {
-    "mocha": "*",
-    "bcrypt": "~0.7.5"
+    "bcrypt": "~0.7.5",
+    "mocha": "~2.0.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -61,6 +61,18 @@ describe('ok', function() {
     });
   });
 
+  describe('no parameter', function() {
+    it('throws error', function(done) {
+      var action = ok();
+      try{
+        action(new Error('expected'));
+      } catch(e) {
+        assert.equal(e.message, 'expected');
+        done();
+      }
+    });
+  });
+
   describe('with domains', function() {
     var domain = require('domain').create();
     assert.equal(process.domain, null);


### PR DESCRIPTION
This PR adds the possibility to use okay without any arguments which is useful in situations where you don't need to wait for the result:

``` js
fs.writeFile(path, 'hello', ok());
```

It also fixes the `keywords` field in package.json which currently results in 
`"d, o, m, a, i, n, d, o, m, a, i, n, s"` being displayed on the npm site.

I also split up the example into an annotated one and one without comments so that it becomes more obvious that the variant with okay is actually shorter ;)
